### PR TITLE
potential plugin bug as the default for "fields" "tabs" does not exis…

### DIFF
--- a/lib/class.profile-cct-admin.php
+++ b/lib/class.profile-cct-admin.php
@@ -586,7 +586,7 @@ class Profile_CCT_Admin {
 				$default = self::default_options( $type );
                 
 				if ( $fields_or_tabs == 'fields' ):
-					$options = $default[$fields_or_tabs][$context];
+					$options = isset( $default[$fields_or_tabs][$context] ) ? $default[$fields_or_tabs][$context] : array();
 				else:
 					$options = $default[$fields_or_tabs];
                 endif;


### PR DESCRIPTION
potential plugin bug as the default for "fields" "tabs" does not exist. Temporarily removed the warning by adding error handling